### PR TITLE
cli: Add a way to list flavors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 dependencies = [
     "kopf>=1.37.0",  # Use newer version for better asyncio compatibility
     "kubernetes>=28.1.0",  # Use newer version to avoid deprecation warnings
+    "rich",
 ]
 
 [project.optional-dependencies]

--- a/src/devserver/cli/main.py
+++ b/src/devserver/cli/main.py
@@ -34,6 +34,8 @@ def main() -> None:
     # 'list' command
     subparsers.add_parser("list", help="List all DevServers.")
 
+    subparsers.add_parser("flavors", help="Show the available flavors.")
+
     # 'delete' command
     parser_delete = subparsers.add_parser("delete", help="Delete a DevServer.")
     parser_delete.add_argument(
@@ -55,6 +57,8 @@ def main() -> None:
         handlers.list_devservers()
     elif args.command == "delete":
         handlers.delete_devserver(name=args.name)
+    elif args.command == "flavors":
+        handlers.list_flavors()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently looks like:

```
❯ devctl flavors
┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ NAME                 ┃ RESOURCES                                                                        ┃
┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ cpu-small            │ {                                                                                │
│                      │     'limits': {'cpu': '2', 'memory': '4Gi'},                                     │
│                      │     'requests': {'cpu': '500m', 'memory': '1Gi'}                                 │
│                      │ }                                                                                │
└──────────────────────┴──────────────────────────────────────────────────────────────────────────────────┘
```

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>