### PR TITLE
cli: Change devctl create to not require a name

### DIFF
--- a/src/devserver/cli/main.py
+++ b/src/devserver/cli/main.py
@@ -11,7 +11,7 @@ def main() -> None:
 
     # 'create' command
     parser_create = subparsers.add_parser("create", help="Create a new DevServer.")
-    parser_create.add_argument("name", type=str, help="The name of the DevServer.")
+    parser_create.add_argument("--name", type=str, help="The name of the DevServer.", default="dev")
     parser_create.add_argument(
         "--flavor", type=str, required=True, help="The flavor of the DevServer."
     )


### PR DESCRIPTION
This should make it so that all devservers are easier to create and that
the assumption should be that your primary devserver should be the same
all of the time.

> [!NOTE]
> I need a change on top of this that will require users to register so that namespaces can be created for devservers

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>