### PR TITLE
operator: Add portable sshd binaries to init container

### DIFF
--- a/src/devserver/operator/resources/configmap.py
+++ b/src/devserver/operator/resources/configmap.py
@@ -1,0 +1,31 @@
+from typing import Any, Dict
+
+def build_configmap(name: str, namespace: str) -> Dict[str, Any]:
+    """Builds the ConfigMap for the DevServer's sshd_config."""
+    
+    sshd_config = """
+# This file is managed by the devserver operator
+
+Port 22
+PermitRootLogin no
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+PrintMotd no
+Subsystem sftp /opt/bin/sftp-server
+AuthorizedKeysFile /home/dev/.ssh/authorized_keys
+HostKey /etc/ssh/hostkeys/ssh_host_rsa_key
+HostKey /etc/ssh/hostkeys/ssh_host_ecdsa_key
+HostKey /etc/ssh/hostkeys/ssh_host_ed25519_key
+    """
+
+    return {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": f"{name}-sshd-config",
+            "namespace": namespace,
+        },
+        "data": {
+            "sshd_config": sshd_config,
+        },
+    }


### PR DESCRIPTION
Enables us to have ssh in the devserver container without
needing to actually install it through the host os.

Also adds a ConfigMap for the sshd_config and a Secret for the host keys.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>