### PR TITLE
operator Adds eks support for GPU, with examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,10 @@ spec:
       nvidia.com/gpu: 1
   nodeSelector:
     instance-type: g4dn.xlarge
+  tolerations:
+    - key: "nvidia.com/gpu"
+      operator: "Exists"
+      effect: "NoSchedule"
 ```
 
 ---

--- a/crds/devserver.io_devserverflavors.yaml
+++ b/crds/devserver.io_devserverflavors.yaml
@@ -33,3 +33,8 @@ spec:
                 nodeSelector:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true

--- a/dev/eks/README.md
+++ b/dev/eks/README.md
@@ -13,10 +13,9 @@ kubectl apply -f dev/eks/
 ```
 
 ## GPU Nodepool
-The `gpu-nodepool.yml` configures a GPU-accelerated nodepool using EKS Auto Mode with:
+The `gpu-nodepool.yml` configures a GPU-accelerated nodepool using Karpenter with:
 - NVIDIA GPU instance types (g6e and g6 families)
-- Automatic GPU driver management
-- Taint `nvidia.com/gpu=true:NoSchedule` to ensure only GPU workloads schedule on these nodes
+- Taint `nvidia.com/gpu:NoSchedule` to ensure only GPU workloads schedule on these nodes
 
 To use GPU nodes in your pods, add:
 ```yaml

--- a/dev/eks/gpu-nodepool.yml
+++ b/dev/eks/gpu-nodepool.yml
@@ -1,35 +1,33 @@
-apiVersion: eks.amazonaws.com/v1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
-  name: gpu-accelerated
+  name: g6-gpu
 spec:
   disruption:
+    budgets:
+    - nodes: 10%
+    consolidateAfter: 1h
     consolidationPolicy: WhenEmpty
-    consolidateAfter: 10m
-  nodeClass:
-    ref:
-      name: default
-  taints:
-    - key: nvidia.com/gpu
-      value: "true"
-      effect: NoSchedule
-  requirements:
-    - key: node.kubernetes.io/instance-type
-      operator: In
-      values:
-        - g6e.xlarge
-        - g6e.2xlarge
-        - g6e.4xlarge
-        - g6e.8xlarge
-        - g6.xlarge
-        - g6.2xlarge
-        - g6.4xlarge
-        - g6.8xlarge
-    - key: kubernetes.io/arch
-      operator: In
-      values:
-        - amd64
-    - key: karpenter.sh/capacity-type
-      operator: In
-      values:
-        - on-demand
+  template:
+    metadata: {}
+    spec:
+      nodeClassRef:
+        group: eks.amazonaws.com
+        kind: NodeClass
+        name: default
+      requirements:
+        - key: "karpenter.sh/capacity-type"
+          operator: In
+          values: ["on-demand"]
+        - key: "kubernetes.io/arch"
+          operator: In
+          values: ["amd64"]
+        - key: "eks.amazonaws.com/instance-family"
+          operator: In
+          values:
+          - g6e
+          - g6
+      taints:
+        - key: nvidia.com/gpu
+          effect: NoSchedule
+      terminationGracePeriod: 24h0m0s

--- a/examples/flavors/gpu-small.yaml
+++ b/examples/flavors/gpu-small.yaml
@@ -14,3 +14,7 @@ spec:
       nvidia.com/gpu: "1"
   nodeSelector:
     kubernetes.io/arch: amd64
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule

--- a/src/devserver/operator/README.md
+++ b/src/devserver/operator/README.md
@@ -48,6 +48,8 @@ spec:
 
 `DevServerFlavor` resources are used to define "t-shirt sizes" for DevServers, specifying resource requests, limits, and node selectors.
 
+Tolerations can also be specified to allow DevServers to be scheduled on nodes with matching taints, such as GPU nodes.
+
 **Example `DevServerFlavor`:**
 
 ```yaml
@@ -64,7 +66,11 @@ spec:
       cpu: "2"
       memory: "4Gi"
   nodeSelector:
-    kubernetes.ioio/arch: amd64
+    kubernetes.io/arch: amd64
+  tolerations:
+    - key: "nvidia.com/gpu"
+      operator: "Exists"
+      effect: "NoSchedule"
 ```
 
 ## Lifecycle Management

--- a/src/devserver/operator/resources/statefulset.py
+++ b/src/devserver/operator/resources/statefulset.py
@@ -17,6 +17,7 @@ def build_statefulset(
             "metadata": {"labels": {"app": name}},
             "spec": {
                 "nodeSelector": flavor["spec"].get("nodeSelector"),
+                "tolerations": flavor["spec"].get("tolerations"),
                 "initContainers": [
                     {
                         "name": "install-sshd",
@@ -112,6 +113,10 @@ def build_statefulset(
     # Remove nodeSelector if it is None
     if not statefulset_spec["template"]["spec"].get("nodeSelector"):
         del statefulset_spec["template"]["spec"]["nodeSelector"]
+
+    # Remove tolerations if it is None
+    if not statefulset_spec["template"]["spec"].get("tolerations"):
+        del statefulset_spec["template"]["spec"]["tolerations"]
 
     # Add shared volume if specified
     if "sharedVolumeClaimName" in spec:


### PR DESCRIPTION
Adds the ability to include tolerations in your DevServerFlavor which
should allow for GPU tolerations and thus for GPUs in general.

I included a sample nodepool that you can deploy to EKS to quickly get
G6 instance types up and running.

If you want to try this out with your EKS cluster you can apply all of
the things in `dev/eks` and `examples/flavors` and then run:

```bash
devctl create --name fedora-gpu --image fedora:latest --flavor gpu-small --ttl 4h
devctl ssh fedora-gpu nvidia-smi
```

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>