### PR TITLE
cli: Switch to kubernetes native port forward

### DIFF
--- a/src/devserver/cli/handlers/ssh.py
+++ b/src/devserver/cli/handlers/ssh.py
@@ -1,11 +1,11 @@
-import re
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 from kubernetes import client, config
 from rich.console import Console
+
+from devserver.utils.network import PortForwardError, kubernetes_port_forward
 
 
 def ssh_devserver(
@@ -38,82 +38,48 @@ def ssh_devserver(
 
     pod_name = f"{name}-0"
 
-    port_forward_proc = None
     try:
-        # Start port forwarding in the background.
-        port_forward_cmd = [
-            "kubectl",
-            "port-forward",
-            f"pod/{pod_name}",
-            ":22",  # Let kubectl pick a random local port
-            f"--namespace={namespace}",
-        ]
-        port_forward_proc = subprocess.Popen(
-            port_forward_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-        )
-
-        # The readline will block until kubectl prints the forwarding info or exits.
-        line = port_forward_proc.stdout.readline()
-
-        local_port = None
-        if "Forwarding from" in line:
-            match = re.search(r":(\d+)\s*->", line)
-            if match:
-                local_port = match.group(1)
-
-        # Give it a moment to stabilize
-        time.sleep(1)
-
-        if not local_port or port_forward_proc.poll() is not None:
-            if port_forward_proc:
-                port_forward_proc.terminate()
-            stderr_output = port_forward_proc.stderr.read()
+        with kubernetes_port_forward(
+            pod_name=pod_name, namespace=namespace, pod_port=22
+        ) as local_port:
             console.print(
-                f"Error: Could not start port-forwarding for DevServer '{name}'. Pod may not be ready."
+                f"Connecting to devserver '{name}' via port-forward on localhost:{local_port}..."
             )
-            if stderr_output:
-                console.print(f"[red]kubectl error: {stderr_output.strip()}[/red]")
-            sys.exit(1)
 
+            key_path = Path(ssh_private_key_file).expanduser()
+            if not key_path.is_file():
+                console.print(
+                    f"[red]Error: SSH private key file not found at '{key_path}'[/red]"
+                )
+                sys.exit(1)
+
+            # We need to add StrictHostKeyChecking=no and UserKnownHostsFile=/dev/null
+            # because the host key of localhost:<port> will change for every connection.
+            ssh_command = [
+                "ssh",
+                "-i",
+                str(key_path),
+                "-p",
+                str(local_port),
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "dev@localhost",
+            ]
+            if remote_command:
+                ssh_command.extend(remote_command)
+
+            subprocess.run(ssh_command, check=False)
+
+    except PortForwardError as e:
         console.print(
-            f"Connecting to devserver '{name}' via port-forward on localhost:{local_port}..."
+            f"Error: Could not start port-forwarding for DevServer '{name}'. Pod may not be ready."
         )
-
-        key_path = Path(ssh_private_key_file).expanduser()
-        if not key_path.is_file():
-            console.print(f"[red]Error: SSH private key file not found at '{key_path}'[/red]")
-            sys.exit(1)
-
-        # We need to add StrictHostKeyChecking=no and UserKnownHostsFile=/dev/null
-        # because the host key of localhost:<port> will change for every connection.
-        ssh_command = [
-            "ssh",
-            "-i",
-            str(key_path),
-            "-p",
-            str(local_port),
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
-            "dev@localhost",
-        ]
-        if remote_command:
-            ssh_command.extend(remote_command)
-
-        subprocess.run(ssh_command, check=False)
-
-    except FileNotFoundError:
-        console.print(
-            "[red]Error: 'kubectl' command not found. Please ensure it is installed and in your PATH.[/red]"
-            "Error: 'kubectl' command not found. Please ensure it is installed and in your PATH."
-        )
+        console.print(f"[red]Error: {e}[/red]")
         sys.exit(1)
     except Exception as e:
         console.print(f"[red]An unexpected error occurred: {e}[/red]")
         sys.exit(1)
     finally:
-        if port_forward_proc and port_forward_proc.poll() is None:
-            console.print("\n[green]SSH session ended. Closing port-forward.[/green]")
-            port_forward_proc.terminate()
-            port_forward_proc.wait()
+        console.print("\n[green]SSH session ended. Closing port-forward.[/green]")

--- a/src/devserver/utils/network.py
+++ b/src/devserver/utils/network.py
@@ -1,0 +1,120 @@
+import contextlib
+import select
+import socket
+import threading
+from typing import Iterator
+
+from kubernetes import client
+from kubernetes.stream import portforward
+from kubernetes.stream.ws_client import PortForward
+
+
+class PortForwardError(Exception):
+    """Custom exception for port forwarding errors."""
+
+
+def _forward_sockets(
+    client_sock: socket.socket, pod_sock: socket.socket, stop_event: threading.Event
+) -> None:
+    """Helper function to forward traffic between two sockets."""
+    sockets = [client_sock, pod_sock]
+    while not stop_event.is_set():
+        readable, _, exceptional = select.select(sockets, [], sockets, 0.5)
+        if exceptional:
+            break
+        for sock in readable:
+            try:
+                data = sock.recv(4096)
+                if not data:
+                    stop_event.set()
+                    break
+                other_sock = pod_sock if sock is client_sock else client_sock
+                other_sock.sendall(data)
+            except Exception:
+                stop_event.set()
+                break
+
+
+@contextlib.contextmanager
+def kubernetes_port_forward(
+    pod_name: str, namespace: str, pod_port: int
+) -> Iterator[int]:
+    """
+    A context manager to handle port forwarding to a Kubernetes pod.
+
+    Args:
+        pod_name: The name of the pod to forward to.
+        namespace: The namespace of the pod.
+        pod_port: The port on the pod to forward to.
+
+    Yields:
+        The local port number that is being forwarded.
+
+    Raises:
+        PortForwardError: If the port forwarding fails to start.
+    """
+    v1 = client.CoreV1Api()
+    stop_forwarding = threading.Event()
+    forwarding_error: list[str] = []
+    local_port = 0
+
+    def forward_traffic(pf: PortForward) -> None:
+        try:
+            # Get the socket to the pod
+            pod_sock = pf.socket(pod_port)
+
+            # Accept incoming connection from the local client
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as local_server:
+                local_server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                local_server.bind(("127.0.0.1", 0))
+                nonlocal local_port
+                local_port = local_server.getsockname()[1]
+                local_server.listen(1)
+
+                # Signal that the local port is ready
+                setup_finished.set()
+
+                local_server.settimeout(10)
+                try:
+                    client_sock, _ = local_server.accept()
+                except socket.timeout:
+                    forwarding_error.append("Timeout waiting for local connection")
+                    return
+
+                _forward_sockets(client_sock, pod_sock, stop_forwarding)
+
+                client_sock.close()
+                pod_sock.close()
+        except Exception as e:
+            forwarding_error.append(str(e))
+        finally:
+            setup_finished.set()
+
+    pf: PortForward = portforward(
+        v1.connect_get_namespaced_pod_portforward,
+        pod_name,
+        namespace,
+        ports=str(pod_port),
+    )
+
+    setup_finished = threading.Event()
+    forward_thread = threading.Thread(
+        target=forward_traffic, args=(pf,), daemon=True
+    )
+    forward_thread.start()
+
+    # Wait for the thread to set up the local port
+    setup_finished.wait(timeout=10)
+
+    if forwarding_error:
+        raise PortForwardError(
+            f"Could not start port-forward: {forwarding_error[0]}"
+        )
+    if local_port == 0:
+        raise PortForwardError("Port forwarding thread failed to start in time.")
+
+    try:
+        yield local_port
+    finally:
+        stop_forwarding.set()
+        forward_thread.join(timeout=2)


### PR DESCRIPTION
Relying on kubectl's port forward gave us a dependency on kubectl, which
is bad so I switched it out with a variant that should work using the
native python client.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>