### PR TITLE
test: Refactor tests to use helpers

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -33,6 +33,7 @@ make down
 
 -   **Integration by Default**: Most tests are integration tests that interact with a real Kubernetes API server.
 -   **Real Resources**: Tests create, manage, and delete real `DevServer` custom resources and verify that the operator creates the expected `StatefulSets`, `Services`, etc.
+-   **Robust Polling**: To avoid flaky tests, the suite uses a set of robust helper functions in `tests/helpers.py` that poll the Kubernetes API to wait for resources to reach their expected state, rather than relying on fixed `time.sleep()` calls.
 -   **CLI Integration**: The test suite also runs `devctl` commands as subprocesses to verify the CLI's behavior against the running operator.
 -   **Session-Scoped Fixtures**: A `k3d` cluster and the running operator are managed by `pytest` session-scoped fixtures for efficiency, meaning they are set up once per test run.
 


### PR DESCRIPTION
The logic for waiting for resources was duplicated in a bunch of places
so refactored it to make it easier to use / manage.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>