### PR TITLE
feat(operator): Use Deployments and support multiple volumes

### DIFF
--- a/crds/devserver.io_devservers.yaml
+++ b/crds/devserver.io_devservers.yaml
@@ -44,15 +44,19 @@ spec:
                     ncclSettings:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                persistentHome:
-                  type: object
-                  properties:
-                    enabled:
-                      type: boolean
-                    size:
-                      type: string
-                sharedVolumeClaimName:
-                  type: string
+                volumes:
+                  type: array
+                  items:
+                    type: object
+                    required: ["claimName", "mountPath"]
+                    properties:
+                      claimName:
+                        type: string
+                      mountPath:
+                        type: string
+                      readOnly:
+                        type: boolean
+                        default: false
                 enableSSH:
                   type: boolean
                 ssh:

--- a/examples/devserver-sample.yaml
+++ b/examples/devserver-sample.yaml
@@ -6,3 +6,16 @@ metadata:
 spec:
   flavor: cpu-small
   image: ubuntu:22.04
+  ssh:
+    publicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ..." # Replace with your SSH public key
+  lifecycle:
+    timeToLive: "4h"
+  enableSSH: true
+  # Optional: Mount persistent volumes (Docker-style)
+  # volumes:
+  #   - claimName: my-home-pvc
+  #     mountPath: /home/dev
+  #     readOnly: false
+  #   - claimName: shared-data-pvc
+  #     mountPath: /data
+  #     readOnly: true

--- a/examples/with-multiple-volumes.yaml
+++ b/examples/with-multiple-volumes.yaml
@@ -1,0 +1,68 @@
+# Example: DevServer with multiple volumes (home + datasets)
+#
+# This example demonstrates how to mount multiple PVCs at different paths,
+# useful for ML workloads where you need separate volumes for home directory,
+# datasets, and output results.
+
+# Prerequisites: Create PVCs first
+# kubectl apply -f - <<EOF
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: alice-home
+#   namespace: default
+# spec:
+#   accessModes: [ReadWriteOnce]
+#   resources:
+#     requests:
+#       storage: 20Gi
+# ---
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: shared-datasets
+#   namespace: default
+# spec:
+#   accessModes: [ReadOnlyMany]
+#   resources:
+#     requests:
+#       storage: 100Gi
+# ---
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: results-output
+#   namespace: default
+# spec:
+#   accessModes: [ReadWriteOnce]
+#   resources:
+#     requests:
+#       storage: 50Gi
+# EOF
+
+# DevServer with multiple volumes
+apiVersion: devserver.io/v1
+kind: DevServer
+metadata:
+  name: alice-ml-dev
+  namespace: default
+spec:
+  flavor: gpu-small
+  image: pytorch/pytorch:latest
+  ssh:
+    publicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ..." # Replace with your SSH public key
+  lifecycle:
+    timeToLive: "8h"
+  enableSSH: true
+
+  # Multiple volumes at different paths
+  volumes:
+    - claimName: alice-home
+      mountPath: /home/dev
+      readOnly: false
+    - claimName: shared-datasets
+      mountPath: /data
+      readOnly: true  # Read-only mount for shared data
+    - claimName: results-output
+      mountPath: /outputs
+      readOnly: false

--- a/examples/with-single-volume.yaml
+++ b/examples/with-single-volume.yaml
@@ -1,0 +1,41 @@
+# Example: DevServer with persistent volume for home directory
+#
+# This example demonstrates how to create a DevServer with a persistent
+# volume mounted at /home/dev. The PVC is created separately and managed
+# by the user, giving full control over storage lifecycle.
+
+# Step 1: Create a PersistentVolumeClaim
+# kubectl apply -f - <<EOF
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: alice-home
+#   namespace: default
+# spec:
+#   accessModes:
+#     - ReadWriteOnce
+#   resources:
+#     requests:
+#       storage: 20Gi
+# EOF
+
+# Step 2: Create the DevServer that uses the PVC
+apiVersion: devserver.io/v1
+kind: DevServer
+metadata:
+  name: alice-dev
+  namespace: default
+spec:
+  flavor: gpu-small
+  image: pytorch/pytorch:latest
+  ssh:
+    publicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ..." # Replace with your SSH public key
+  lifecycle:
+    timeToLive: "8h"
+  enableSSH: true
+
+  # Docker-style volume mounting
+  volumes:
+    - claimName: alice-home
+      mountPath: /home/dev
+      readOnly: false

--- a/src/devservers/cli/main.py
+++ b/src/devservers/cli/main.py
@@ -77,10 +77,11 @@ def main(ctx, config_path, assume_yes) -> None:
     help="Wait for the DevServer to be ready.",
 )
 @click.option(
-    "--persistent-home-size",
-    type=str,
-    default="10Gi",
-    help="The size of the persistent home directory.",
+    "-v",
+    "--volume",
+    "volumes",
+    multiple=True,
+    help="Mount volume (format: PVC_NAME:/path or PVC_NAME:/path:ro). Can be specified multiple times.",
 )
 @click.pass_context
 def create(
@@ -91,7 +92,7 @@ def create(
     ssh_public_key_file: str,
     time_to_live: str,
     wait: bool,
-    persistent_home_size: str,
+    volumes: tuple[str, ...],
 ) -> None:
     """Create a new DevServer."""
     handlers.create_devserver(
@@ -102,7 +103,7 @@ def create(
         ssh_public_key_file=ssh_public_key_file,
         time_to_live=time_to_live,
         wait=wait,
-        persistent_home_size=persistent_home_size,
+        volumes=volumes,
     )
 
 

--- a/src/devservers/crds/__init__.py
+++ b/src/devservers/crds/__init__.py
@@ -1,3 +1,3 @@
-from .devserver import DevServer, PersistentHomeSpec
+from .devserver import DevServer
 
-__all__ = ["DevServer", "PersistentHomeSpec"]
+__all__ = ["DevServer"]

--- a/src/devservers/operator/README.md
+++ b/src/devservers/operator/README.md
@@ -14,12 +14,12 @@ The operator introduces two Custom Resource Definitions (CRDs):
 
 When a `DevServer` resource is created or updated, the operator provisions the necessary Kubernetes objects to run the development environment, including:
 
--   A `StatefulSet` to manage the pod.
+-   A `Deployment` to manage the pod.
 -   `Services` for network access (including SSH).
 -   A `Secret` for SSH host keys. The operator will automatically generate this secret if it doesn't exist.
 -   A `ConfigMap` for the SSH daemon configuration, which includes a custom message of the day (motd) and allows SSH agent forwarding.
 
-The operator watches for changes to `DevServer` resources and will automatically apply updates. For example, changing the `image` in a `DevServer`'s `spec` will cause the operator to update the `StatefulSet` to roll out a new pod with the new image.
+The operator watches for changes to `DevServer` resources and will automatically apply updates. For example, changing the `image` in a `DevServer`'s `spec` will cause the operator to update the `Deployment` to roll out a new pod with the new image.
 
 ### Container Startup Script
 

--- a/src/devservers/operator/config.py
+++ b/src/devservers/operator/config.py
@@ -6,7 +6,6 @@ import yaml
 logger = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_PATH = "/etc/devserver-operator/config.yaml"
-DEFAULT_PERSISTENT_HOME_SIZE = "10Gi"
 DEFAULT_EXPIRATION_INTERVAL = 60
 DEFAULT_FLAVOR_RECONCILIATION_INTERVAL = 60
 DEFAULT_WORKER_LIMIT = 1
@@ -25,11 +24,6 @@ class OperatorConfig:
         def get_bool(value):
             return str(value).lower() in ("true", "1", "t")
 
-        self.default_persistent_home_size = self._get_value(
-            "DEVSERVER_DEFAULT_PERSISTENT_HOME_SIZE",
-            "defaultPersistentHomeSize",
-            DEFAULT_PERSISTENT_HOME_SIZE,
-        )
         self.expiration_interval = self._get_value(
             "DEVSERVER_EXPIRATION_INTERVAL",
             "expirationInterval",

--- a/src/devservers/operator/devserver/handler.py
+++ b/src/devservers/operator/devserver/handler.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 import kopf
 from kubernetes import client
 
-from .validation import validate_and_normalize_ttl
+from .validation import validate_and_normalize_ttl, validate_volumes
 from .host_keys import ensure_host_keys_secret
 from .reconciler import reconcile_devserver
 from ..config import config as operator_config
@@ -43,6 +43,10 @@ async def create_or_update_devserver(
     # Step 1: Validate TTL
     ttl_str = spec.get("lifecycle", {}).get("timeToLive")
     validate_and_normalize_ttl(ttl_str, logger)
+
+    # Step 1b: Validate volumes
+    volumes = spec.get("volumes")
+    validate_volumes(volumes, logger)
 
     # Step 2: Get the DevServerFlavor
     custom_objects_api = client.CustomObjectsApi()

--- a/src/devservers/operator/devserver/handler.py
+++ b/src/devservers/operator/devserver/handler.py
@@ -77,7 +77,6 @@ async def create_or_update_devserver(
         spec,
         flavor,
         logger,
-        default_persistent_home_size=operator_config.default_persistent_home_size,
         default_devserver_image=operator_config.default_devserver_image,
         static_dependencies_image=operator_config.static_dependencies_image,
     )
@@ -95,15 +94,12 @@ async def delete_devserver(
     """
     Handle the deletion of a DevServer resource.
 
-    The StatefulSet and Services are owned by the DevServer via owner
+    The Deployment and Services are owned by the DevServer via owner
     references and will be garbage collected automatically.
 
-    Note: PVCs from StatefulSets are NOT automatically deleted to prevent
-    data loss. Administrators may need to clean them up manually.
+    Note: User-managed PVCs are NOT automatically deleted. Users must
+    manage their PVC lifecycle independently.
     """
     #TODO: Make a snapshot of the container
     logger.info(f"DevServer '{name}' in namespace '{namespace}' is being deleted.")
-    logger.info("Associated StatefulSet and Services will be garbage collected.")
-    logger.warning(
-        f"PersistentVolumeClaim for '{name}' will NOT be deleted automatically."
-    )
+    logger.info("Associated Deployment and Services will be garbage collected.")

--- a/src/devservers/operator/devserver/reconciler.py
+++ b/src/devservers/operator/devserver/reconciler.py
@@ -10,8 +10,8 @@ import kopf
 from kubernetes import client
 
 from .resources.configmap import build_configmap, build_startup_configmap, build_login_configmap
-from .resources.services import build_headless_service, build_ssh_service
-from .resources.statefulset import build_statefulset
+from .resources.services import build_ssh_service
+from .resources.deployment import build_deployment
 
 
 class DevServerReconciler:
@@ -25,7 +25,6 @@ class DevServerReconciler:
         namespace: str,
         spec: Dict[str, Any],
         flavor: Dict[str, Any],
-        default_persistent_home_size: str,
         default_devserver_image: str,
         static_dependencies_image: str,
     ):
@@ -33,7 +32,6 @@ class DevServerReconciler:
         self.namespace = namespace
         self.spec = spec
         self.flavor = flavor
-        self.default_persistent_home_size = default_persistent_home_size
         self.default_devserver_image = default_devserver_image
         self.static_dependencies_image = static_dependencies_image
         self.core_v1 = client.CoreV1Api()
@@ -47,16 +45,14 @@ class DevServerReconciler:
             Dictionary of resource objects keyed by resource type.
         """
         # Build services
-        headless_service = build_headless_service(self.name, self.namespace)
         ssh_service = build_ssh_service(self.name, self.namespace)
 
-        # Build StatefulSet
-        statefulset = build_statefulset(
+        # Build Deployment
+        deployment = build_deployment(
             self.name,
             self.namespace,
             self.spec,
             self.flavor,
-            self.default_persistent_home_size,
             self.default_devserver_image,
             self.static_dependencies_image,
         )
@@ -77,9 +73,8 @@ class DevServerReconciler:
             self.name, self.namespace, user_login_script_content
         )
         return {
-            "headless_service": headless_service,
             "ssh_service": ssh_service,
-            "statefulset": statefulset,
+            "deployment": deployment,
             "sshd_configmap": sshd_configmap,
             "startup_script_configmap": startup_script_configmap,
             "user_login_script_configmap": user_login_script_configmap,
@@ -109,16 +104,14 @@ class DevServerReconciler:
         await self._reconcile_configmap(resources["user_login_script_configmap"], logger)
 
         # Reconcile Services
-        await self._reconcile_service(resources["headless_service"], logger)
-
         if self.spec.get("enableSSH", False):
             await self._reconcile_service(resources["ssh_service"], logger)
         else:
             # TODO: Handle disabling SSH on an existing DevServer by deleting the service
             pass
 
-        # Reconcile StatefulSet
-        await self._reconcile_statefulset(resources["statefulset"], logger)
+        # Reconcile Deployment
+        await self._reconcile_deployment(resources["deployment"], logger)
 
     async def _reconcile_configmap(self, configmap: Dict[str, Any], logger: logging.Logger) -> None:
         """Create or update a ConfigMap."""
@@ -174,30 +167,30 @@ class DevServerReconciler:
             else:
                 raise
 
-    async def _reconcile_statefulset(self, statefulset: Dict[str, Any], logger: logging.Logger) -> None:
-        """Create or update a StatefulSet."""
-        name = statefulset["metadata"]["name"]
+    async def _reconcile_deployment(self, deployment: Dict[str, Any], logger: logging.Logger) -> None:
+        """Create or update a Deployment."""
+        name = deployment["metadata"]["name"]
         try:
             await asyncio.to_thread(
-                self.apps_v1.read_namespaced_stateful_set, name=name, namespace=self.namespace
+                self.apps_v1.read_namespaced_deployment, name=name, namespace=self.namespace
             )
             # It exists, so we patch it
             await asyncio.to_thread(
-                self.apps_v1.patch_namespaced_stateful_set,
+                self.apps_v1.patch_namespaced_deployment,
                 name=name,
                 namespace=self.namespace,
-                body=statefulset,
+                body=deployment,
             )
-            logger.info(f"StatefulSet '{name}' patched.")
+            logger.info(f"Deployment '{name}' patched.")
         except client.ApiException as e:
             if e.status == 404:
                 # It does not exist, so we create it
                 await asyncio.to_thread(
-                    self.apps_v1.create_namespaced_stateful_set,
-                    body=statefulset,
+                    self.apps_v1.create_namespaced_deployment,
+                    body=deployment,
                     namespace=self.namespace,
                 )
-                logger.info(f"StatefulSet '{name}' created for DevServer.")
+                logger.info(f"Deployment '{name}' created for DevServer.")
             else:
                 raise
 
@@ -208,7 +201,6 @@ async def reconcile_devserver(
     spec: Dict[str, Any],
     flavor: Dict[str, Any],
     logger: logging.Logger,
-    default_persistent_home_size: str,
     default_devserver_image: str,
     static_dependencies_image: str,
 ) -> str:
@@ -230,7 +222,6 @@ async def reconcile_devserver(
         namespace,
         spec,
         flavor,
-        default_persistent_home_size,
         default_devserver_image,
         static_dependencies_image,
     )
@@ -244,4 +235,4 @@ async def reconcile_devserver(
     # Create or update resources
     await reconciler.reconcile_resources(resources, logger)
 
-    return f"StatefulSet '{name}' reconciled successfully."
+    return f"Deployment '{name}' reconciled successfully."

--- a/src/devservers/operator/devserver/resources/deployment.py
+++ b/src/devservers/operator/devserver/resources/deployment.py
@@ -17,6 +17,7 @@ def build_deployment(
 
     deployment_spec = {
         "replicas": 1,
+        "strategy": {"type": "Recreate"},
         "selector": {"matchLabels": {"app": name}},
         "template": {
             "metadata": {"labels": {"app": name}},

--- a/src/devservers/operator/devserver/resources/services.py
+++ b/src/devservers/operator/devserver/resources/services.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 
 def build_headless_service(name: str, namespace: str) -> Dict[str, Any]:
-    """Builds the headless Service for the StatefulSet."""
+    """Builds the headless Service for the Deployment."""
     return {
         "apiVersion": "v1",
         "kind": "Service",

--- a/src/devservers/operator/devserver/validation.py
+++ b/src/devservers/operator/devserver/validation.py
@@ -3,6 +3,7 @@ Validation and normalization for DevServer resources.
 """
 import logging
 from datetime import timedelta
+from typing import Any, Dict, List
 
 import kopf
 
@@ -30,3 +31,32 @@ def validate_and_normalize_ttl(
     except ValueError as e:
         logger.error(f"Invalid timeToLive value '{ttl_str}': {e}")
         raise kopf.PermanentError(f"Invalid timeToLive: {e}")
+
+
+def validate_volumes(
+    volumes: List[Dict[str, Any]] | None,
+    logger: logging.Logger,
+) -> None:
+    """
+    Validate volume configuration for duplicate mount paths.
+    Raises a PermanentError if validation fails.
+    """
+    if not volumes:
+        return
+
+    mount_paths = []
+    for idx, volume in enumerate(volumes):
+        if not isinstance(volume, dict):
+            logger.error(f"Volume at index {idx} is not a dictionary.")
+            raise kopf.PermanentError(f"Volume at index {idx} must be a dictionary.")
+
+        mount_path = volume.get("mountPath")
+        if not mount_path:
+            logger.error(f"Volume at index {idx} is missing required field 'mountPath'.")
+            raise kopf.PermanentError(f"Volume at index {idx} is missing required field 'mountPath'.")
+
+        if mount_path in mount_paths:
+            logger.error(f"Duplicate mount path '{mount_path}' found in volumes.")
+            raise kopf.PermanentError(f"Duplicate mount path '{mount_path}' is not allowed. Each volume must have a unique mount path.")
+
+        mount_paths.append(mount_path)

--- a/src/devservers/operator/operator.py
+++ b/src/devservers/operator/operator.py
@@ -57,9 +57,6 @@ async def on_startup(
         raise kopf.PermanentError(str(exc)) from exc
 
     logger.info("Operator started.")
-    logger.info(
-        f"Default persistent home size: {operator_config.default_persistent_home_size}"
-    )
 
     # The default worker limit is unbounded which means you can EASILY flood
     # your API server on restart unless you limit it. 1-5 are the generally

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,7 +36,7 @@ make test MAX_JOBS=8
 ## Test Philosophy
 
 -   **Integration by Default**: Most tests are integration tests that interact with a real Kubernetes API server.
--   **Real Resources**: Tests create, manage, and delete real `DevServer` custom resources and verify that the operator creates the expected `StatefulSets`, `Services`, etc.
+-   **Real Resources**: Tests create, manage, and delete real `DevServer` custom resources and verify that the operator creates the expected `Deployments`, `Services`, etc.
 -   **Robust Polling**: To avoid flaky tests, the suite uses a set of robust helper functions in `tests/helpers.py` that poll the Kubernetes API to wait for resources to reach their expected state, rather than relying on fixed `time.sleep()` calls.
 -   **DevServer Fixtures**: Most tests now rely on the `devserver_factory` (sync) and `async_devserver` (async) fixtures, which wrap the `DevServer` CRD context manager. They create the resource, wait for readiness, and ensure cleanup without duplicating polling logic in each test.
 -   **CLI Integration**: The test suite also runs `devctl` commands as subprocesses to verify the CLI's behavior against the running operator.

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -44,14 +44,14 @@ def test_devserver_missing_flavor_error(
 
         time.sleep(2)  # Give operator time to process
 
-        # Verify that no statefulset was created due to the error
+        # Verify that no deployment was created due to the error
         with pytest.raises(client.ApiException) as exc_info:
-            apps_v1.read_namespaced_stateful_set(
+            apps_v1.read_namespaced_deployment(
                 name=devserver_name, namespace=NAMESPACE
             )
         assert isinstance(exc_info.value, client.ApiException)
         assert exc_info.value.status == 404, (
-            "StatefulSet should not exist for invalid flavor"
+            "Deployment should not exist for invalid flavor"
         )
 
     finally:

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -131,7 +131,7 @@ def test_build_deployment_with_single_volume():
     assert home_volume is None, "home emptyDir volume should not exist when volumes are specified"
 
     # Should have user volume
-    user_volume = next((v for v in volumes if v.get("name", "").startswith("user-volume-")), None)
+    user_volume = next((v for v in volumes if v.get("name", "").startswith("vol-")), None)
     assert user_volume is not None, "user volume not found"
     assert "persistentVolumeClaim" in user_volume
     assert user_volume["persistentVolumeClaim"]["claimName"] == "my-pvc"
@@ -139,7 +139,7 @@ def test_build_deployment_with_single_volume():
     # Should have mount at /home/dev
     container = deployment["spec"]["template"]["spec"]["containers"][0]
     user_mount = next(
-        (vm for vm in container["volumeMounts"] if vm.get("name", "").startswith("user-volume-")),
+        (vm for vm in container["volumeMounts"] if vm.get("name", "").startswith("vol-")),
         None
     )
     assert user_mount is not None, "user mount not found"
@@ -183,7 +183,7 @@ def test_build_deployment_with_multiple_volumes():
 
     # Should have 3 user volumes
     volumes = deployment["spec"]["template"]["spec"]["volumes"]
-    user_volumes = [v for v in volumes if v.get("name", "").startswith("user-volume-")]
+    user_volumes = [v for v in volumes if v.get("name", "").startswith("vol-")]
     assert len(user_volumes) == 3, f"Expected 3 user volumes, got {len(user_volumes)}"
 
     # Verify PVC claim names
@@ -194,7 +194,7 @@ def test_build_deployment_with_multiple_volumes():
     container = deployment["spec"]["template"]["spec"]["containers"][0]
     user_mounts = [
         vm for vm in container["volumeMounts"]
-        if vm.get("name", "").startswith("user-volume-")
+        if vm.get("name", "").startswith("vol-")
     ]
     assert len(user_mounts) == 3, f"Expected 3 user mounts, got {len(user_mounts)}"
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,10 +1,10 @@
 import pytest
-from devservers.operator.devserver.resources.statefulset import build_statefulset
+from devservers.operator.devserver.resources.deployment import build_deployment
 from devservers.operator.devserveruser.reconciler import DevServerUserReconciler
 from unittest.mock import MagicMock
 from kubernetes.client.rest import ApiException
 
-def test_build_statefulset_with_node_selector():
+def test_build_deployment_with_node_selector():
     name = "test-server"
     namespace = "test-ns"
     spec = {
@@ -25,23 +25,22 @@ def test_build_statefulset_with_node_selector():
         }
     }
 
-    statefulset = build_statefulset(
+    deployment = build_deployment(
         name,
         namespace,
         spec,
         flavor,
-        default_persistent_home_size="10Gi",
         default_devserver_image="default-image",
         static_dependencies_image="static-image",
     )
 
-    assert "nodeSelector" in statefulset["spec"]["template"]["spec"]
-    assert statefulset["spec"]["template"]["spec"]["nodeSelector"] == {
+    assert "nodeSelector" in deployment["spec"]["template"]["spec"]
+    assert deployment["spec"]["template"]["spec"]["nodeSelector"] == {
         "disktype": "ssd",
         "team": "backend"
     }
 
-def test_build_statefulset_without_node_selector():
+def test_build_deployment_without_node_selector():
     name = "test-server"
     namespace = "test-ns"
     spec = {
@@ -58,105 +57,179 @@ def test_build_statefulset_without_node_selector():
         }
     }
 
-    statefulset = build_statefulset(
+    deployment = build_deployment(
         name,
         namespace,
         spec,
         flavor,
-        default_persistent_home_size="10Gi",
         default_devserver_image="default-image",
         static_dependencies_image="static-image",
     )
 
-    assert "nodeSelector" not in statefulset["spec"]["template"]["spec"]
+    assert "nodeSelector" not in deployment["spec"]["template"]["spec"]
 
 
-def test_build_statefulset_with_persistent_home_enabled():
-    name = "test-server"
-    namespace = "test-ns"
-    spec = {"persistentHome": {"enabled": True}}
-    flavor = {"spec": {"resources": {}}}
-
-    statefulset = build_statefulset(
-        name,
-        namespace,
-        spec,
-        flavor,
-        default_persistent_home_size="10Gi",
-        default_devserver_image="default-image",
-        static_dependencies_image="static-image",
-    )
-
-    assert "volumeClaimTemplates" in statefulset["spec"]
-    vct = statefulset["spec"]["volumeClaimTemplates"][0]
-    assert vct["metadata"]["name"] == "home"
-    assert vct["spec"]["resources"]["requests"]["storage"] == "10Gi"
-
-    volumes = statefulset["spec"]["template"]["spec"]["volumes"]
-    assert not any(v.get("name") == "home" and "emptyDir" in v for v in volumes)
-
-
-def test_build_statefulset_with_persistent_home_enabled_and_size():
-    name = "test-server"
-    namespace = "test-ns"
-    spec = {"persistentHome": {"enabled": True, "size": "20Gi"}}
-    flavor = {"spec": {"resources": {}}}
-
-    statefulset = build_statefulset(
-        name,
-        namespace,
-        spec,
-        flavor,
-        default_persistent_home_size="10Gi",
-        default_devserver_image="default-image",
-        static_dependencies_image="static-image",
-    )
-
-    assert "volumeClaimTemplates" in statefulset["spec"]
-    vct = statefulset["spec"]["volumeClaimTemplates"][0]
-    assert vct["spec"]["resources"]["requests"]["storage"] == "20Gi"
-
-
-def test_build_statefulset_with_persistent_home_disabled():
-    name = "test-server"
-    namespace = "test-ns"
-    spec = {"persistentHome": {"enabled": False}}
-    flavor = {"spec": {"resources": {}}}
-
-    statefulset = build_statefulset(
-        name,
-        namespace,
-        spec,
-        flavor,
-        default_persistent_home_size="10Gi",
-        default_devserver_image="default-image",
-        static_dependencies_image="static-image",
-    )
-
-    assert "volumeClaimTemplates" not in statefulset["spec"]
-    volumes = statefulset["spec"]["template"]["spec"]["volumes"]
-    assert any(v.get("name") == "home" and "emptyDir" in v for v in volumes)
-
-
-def test_build_statefulset_with_persistent_home_unspecified():
+def test_build_deployment_with_no_volumes():
+    """Test that no volumes specified results in emptyDir at /home/dev"""
     name = "test-server"
     namespace = "test-ns"
     spec = {}
     flavor = {"spec": {"resources": {}}}
 
-    statefulset = build_statefulset(
+    deployment = build_deployment(
         name,
         namespace,
         spec,
         flavor,
-        default_persistent_home_size="10Gi",
         default_devserver_image="default-image",
         static_dependencies_image="static-image",
     )
 
-    assert "volumeClaimTemplates" not in statefulset["spec"]
-    volumes = statefulset["spec"]["template"]["spec"]["volumes"]
-    assert any(v.get("name") == "home" and "emptyDir" in v for v in volumes)
+    # Should have emptyDir volume named "home"
+    volumes = deployment["spec"]["template"]["spec"]["volumes"]
+    home_volume = next((v for v in volumes if v.get("name") == "home"), None)
+    assert home_volume is not None, "home volume not found"
+    assert "emptyDir" in home_volume, "home volume should be emptyDir"
+
+    # Should have mount at /home/dev
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    home_mount = next(
+        (vm for vm in container["volumeMounts"] if vm.get("name") == "home"),
+        None
+    )
+    assert home_mount is not None, "home mount not found"
+    assert home_mount["mountPath"] == "/home/dev"
+
+
+def test_build_deployment_with_single_volume():
+    """Test that a single volume is mounted correctly"""
+    name = "test-server"
+    namespace = "test-ns"
+    spec = {
+        "volumes": [
+            {
+                "claimName": "my-pvc",
+                "mountPath": "/home/dev",
+                "readOnly": False
+            }
+        ]
+    }
+    flavor = {"spec": {"resources": {}}}
+
+    deployment = build_deployment(
+        name,
+        namespace,
+        spec,
+        flavor,
+        default_devserver_image="default-image",
+        static_dependencies_image="static-image",
+    )
+
+    # Should NOT have emptyDir home volume
+    volumes = deployment["spec"]["template"]["spec"]["volumes"]
+    home_volume = next((v for v in volumes if v.get("name") == "home"), None)
+    assert home_volume is None, "home emptyDir volume should not exist when volumes are specified"
+
+    # Should have user volume
+    user_volume = next((v for v in volumes if v.get("name", "").startswith("user-volume-")), None)
+    assert user_volume is not None, "user volume not found"
+    assert "persistentVolumeClaim" in user_volume
+    assert user_volume["persistentVolumeClaim"]["claimName"] == "my-pvc"
+
+    # Should have mount at /home/dev
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    user_mount = next(
+        (vm for vm in container["volumeMounts"] if vm.get("name", "").startswith("user-volume-")),
+        None
+    )
+    assert user_mount is not None, "user mount not found"
+    assert user_mount["mountPath"] == "/home/dev"
+    assert not user_mount["readOnly"]
+
+
+def test_build_deployment_with_multiple_volumes():
+    """Test that multiple volumes are mounted correctly"""
+    name = "test-server"
+    namespace = "test-ns"
+    spec = {
+        "volumes": [
+            {
+                "claimName": "home-pvc",
+                "mountPath": "/home/dev",
+                "readOnly": False
+            },
+            {
+                "claimName": "data-pvc",
+                "mountPath": "/data",
+                "readOnly": True
+            },
+            {
+                "claimName": "output-pvc",
+                "mountPath": "/outputs",
+                "readOnly": False
+            }
+        ]
+    }
+    flavor = {"spec": {"resources": {}}}
+
+    deployment = build_deployment(
+        name,
+        namespace,
+        spec,
+        flavor,
+        default_devserver_image="default-image",
+        static_dependencies_image="static-image",
+    )
+
+    # Should have 3 user volumes
+    volumes = deployment["spec"]["template"]["spec"]["volumes"]
+    user_volumes = [v for v in volumes if v.get("name", "").startswith("user-volume-")]
+    assert len(user_volumes) == 3, f"Expected 3 user volumes, got {len(user_volumes)}"
+
+    # Verify PVC claim names
+    claim_names = {v["persistentVolumeClaim"]["claimName"] for v in user_volumes}
+    assert claim_names == {"home-pvc", "data-pvc", "output-pvc"}
+
+    # Should have 3 user mounts
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    user_mounts = [
+        vm for vm in container["volumeMounts"]
+        if vm.get("name", "").startswith("user-volume-")
+    ]
+    assert len(user_mounts) == 3, f"Expected 3 user mounts, got {len(user_mounts)}"
+
+    # Verify mount paths and read-only flags
+    mount_paths = {vm["mountPath"]: vm for vm in user_mounts}
+    assert "/home/dev" in mount_paths
+    assert "/data" in mount_paths
+    assert "/outputs" in mount_paths
+    assert mount_paths["/data"]["readOnly"]
+    assert not mount_paths["/home/dev"]["readOnly"]
+    assert not mount_paths["/outputs"]["readOnly"]
+
+
+def test_build_deployment_kind_is_deployment():
+    """Test that the resource kind is Deployment, not StatefulSet"""
+    name = "test-server"
+    namespace = "test-ns"
+    spec = {}
+    flavor = {"spec": {"resources": {}}}
+
+    deployment = build_deployment(
+        name,
+        namespace,
+        spec,
+        flavor,
+        default_devserver_image="default-image",
+        static_dependencies_image="static-image",
+    )
+
+    assert deployment["kind"] == "Deployment"
+    assert deployment["apiVersion"] == "apps/v1"
+    # Should NOT have serviceName field (that's StatefulSet-specific)
+    assert "serviceName" not in deployment["spec"]
+    # Should NOT have volumeClaimTemplates (that's StatefulSet-specific)
+    assert "volumeClaimTemplates" not in deployment["spec"]
 
 
 def test_compute_user_namespace_default():

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -232,6 +232,25 @@ def test_build_deployment_kind_is_deployment():
     assert "volumeClaimTemplates" not in deployment["spec"]
 
 
+def test_build_deployment_uses_recreate_strategy():
+    """Deployment should use Recreate strategy for RWO volumes"""
+    name = "test-server"
+    namespace = "test-ns"
+    spec = {}
+    flavor = {"spec": {"resources": {}}}
+
+    deployment = build_deployment(
+        name,
+        namespace,
+        spec,
+        flavor,
+        default_devserver_image="default-image",
+        static_dependencies_image="static-image",
+    )
+
+    assert deployment["spec"].get("strategy") == {"type": "Recreate"}
+
+
 def test_compute_user_namespace_default():
     spec = {"username": "alice"}
     reconciler = DevServerUserReconciler(spec=spec, metadata={})

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -5,9 +5,7 @@ from tests.conftest import TEST_NAMESPACE
 from tests.helpers import (
     build_devserver_spec,
     wait_for_devserver_status,
-    wait_for_pvc_to_exist,
-    wait_for_statefulset_to_exist,
-    wait_for_statefulset_to_be_deleted,
+    wait_for_deployment_to_exist,
 )
 
 # Constants from the main test file
@@ -15,89 +13,313 @@ NAMESPACE = TEST_NAMESPACE
 
 
 @pytest.mark.asyncio
-async def test_persistent_storage_retains_on_recreation(
+async def test_ephemeral_storage_with_no_volumes(
     test_flavor, operator_running, k8s_clients, async_devserver
 ):
     """
-    Tests that a DevServer with persistentHomeSize correctly creates a
-    StatefulSet with a volumeClaimTemplate and a corresponding PVC. It also
-    tests that the PVC is retained when a DevServer is deleted and then
-    re-attached when the same DevServer is recreated.
+    Tests that a DevServer with no volumes specified gets an emptyDir
+    mounted at /home/dev (ephemeral storage).
     """
     apps_v1 = k8s_clients["apps_v1"]
-    core_v1 = k8s_clients["core_v1"]
-    devserver_name = "test-recreation"
-    storage_size = "1Gi"
-    pvc_name = f"home-{devserver_name}-0"
+    devserver_name = "test-ephemeral"
 
     devserver_spec = build_devserver_spec(
         flavor=test_flavor,
         public_key="ssh-rsa AAAA...",
         ttl="1h",
         image=None,
-        overrides={"persistentHome": {"enabled": True, "size": storage_size}},
     )
 
-    # 1. Initial Creation
-    print("PHASE 1: Creating DevServer and PVC...")
     async with async_devserver(
         devserver_name,
         spec=devserver_spec,
     ):
-        # 1a. Verify the StatefulSet's volumeClaimTemplate has the correct size
-        statefulset = await wait_for_statefulset_to_exist(
+        # Verify the Deployment has an emptyDir volume at /home/dev
+        deployment = await wait_for_deployment_to_exist(
             apps_v1, name=devserver_name, namespace=NAMESPACE
         )
 
-        assert statefulset is not None
-        vct = statefulset.spec.volume_claim_templates[0]
-        assert vct.spec.resources.requests["storage"] == storage_size
+        assert deployment is not None
 
-        # 1b. Verify the PVC is created by the StatefulSet controller
-        pvc = await wait_for_pvc_to_exist(core_v1, name=pvc_name, namespace=NAMESPACE)
+        # Check volumes
+        volumes = deployment.spec.template.spec.volumes
+        home_volume = next((v for v in volumes if v.name == "home"), None)
+        assert home_volume is not None, "home volume not found"
+        assert home_volume.empty_dir is not None, "home volume should be emptyDir"
 
-        assert pvc is not None, f"PVC '{pvc_name}' was not created."
-        assert pvc.spec.resources.requests["storage"] == storage_size
-        print(f"✅ PVC '{pvc_name}' created.")
+        # Check volume mounts
+        container = deployment.spec.template.spec.containers[0]
+        home_mount = next((vm for vm in container.volume_mounts if vm.name == "home"), None)
+        assert home_mount is not None, "home mount not found"
+        assert home_mount.mount_path == "/home/dev"
 
-    # Wait for StatefulSet to be deleted
-    await wait_for_statefulset_to_be_deleted(
-        apps_v1, name=devserver_name, namespace=NAMESPACE
+        print("✅ Ephemeral storage (emptyDir) correctly configured at /home/dev")
+
+
+@pytest.mark.asyncio
+async def test_single_volume_mount(
+    test_flavor, operator_running, k8s_clients, async_devserver
+):
+    """
+    Tests that a DevServer with a single volume mounts it correctly.
+    """
+    apps_v1 = k8s_clients["apps_v1"]
+    core_v1 = k8s_clients["core_v1"]
+    devserver_name = "test-single-volume"
+    pvc_name = "test-pvc-home"
+
+    # Create a PVC for testing
+    pvc_manifest = client.V1PersistentVolumeClaim(
+        metadata=client.V1ObjectMeta(name=pvc_name, namespace=NAMESPACE),
+        spec=client.V1PersistentVolumeClaimSpec(
+            access_modes=["ReadWriteOnce"],
+            resources=client.V1ResourceRequirements(requests={"storage": "1Gi"}),
+        ),
     )
-    print(f"✅ StatefulSet '{devserver_name}' deleted.")
 
-    # Assert that the PVC still exists
     try:
         await asyncio.to_thread(
+            core_v1.create_namespaced_persistent_volume_claim,
+            namespace=NAMESPACE,
+            body=pvc_manifest,
+        )
+        print(f"✅ PVC '{pvc_name}' created for testing")
+
+        devserver_spec = build_devserver_spec(
+            flavor=test_flavor,
+            public_key="ssh-rsa AAAA...",
+            ttl="1h",
+            image=None,
+            volumes=[
+                {
+                    "claimName": pvc_name,
+                    "mountPath": "/home/dev",
+                    "readOnly": False,
+                }
+            ],
+        )
+
+        async with async_devserver(
+            devserver_name,
+            spec=devserver_spec,
+        ):
+            # Verify the Deployment mounts the PVC
+            deployment = await wait_for_deployment_to_exist(
+                apps_v1, name=devserver_name, namespace=NAMESPACE
+            )
+
+            assert deployment is not None
+
+            # Check volumes
+            volumes = deployment.spec.template.spec.volumes
+            user_volume = next((v for v in volumes if v.name.startswith("user-volume-")), None)
+            assert user_volume is not None, "user volume not found"
+            assert user_volume.persistent_volume_claim is not None
+            assert user_volume.persistent_volume_claim.claim_name == pvc_name
+
+            # Check volume mounts
+            container = deployment.spec.template.spec.containers[0]
+            user_mount = next(
+                (vm for vm in container.volume_mounts if vm.name.startswith("user-volume-")),
+                None
+            )
+            assert user_mount is not None, "user mount not found"
+            assert user_mount.mount_path == "/home/dev"
+            assert not user_mount.read_only
+
+            print(f"✅ Single volume '{pvc_name}' correctly mounted at /home/dev")
+
+    finally:
+        # Cleanup PVC
+        try:
+            await asyncio.to_thread(
+                core_v1.delete_namespaced_persistent_volume_claim,
+                name=pvc_name,
+                namespace=NAMESPACE,
+            )
+            print(f"🧹 PVC '{pvc_name}' deleted")
+        except client.ApiException as e:
+            if e.status != 404:
+                print(f"⚠️ Error deleting PVC '{pvc_name}': {e}")
+
+
+@pytest.mark.asyncio
+async def test_multiple_volume_mounts(
+    test_flavor, operator_running, k8s_clients, async_devserver
+):
+    """
+    Tests that a DevServer can mount multiple PVCs at different paths.
+    """
+    apps_v1 = k8s_clients["apps_v1"]
+    core_v1 = k8s_clients["core_v1"]
+    devserver_name = "test-multi-volumes"
+    pvc_home = "test-pvc-multi-home"
+    pvc_data = "test-pvc-multi-data"
+
+    # Create PVCs for testing
+    pvcs_to_create = [
+        (pvc_home, "/home/dev"),
+        (pvc_data, "/data"),
+    ]
+
+    created_pvcs = []
+
+    try:
+        for pvc_name, _ in pvcs_to_create:
+            pvc_manifest = client.V1PersistentVolumeClaim(
+                metadata=client.V1ObjectMeta(name=pvc_name, namespace=NAMESPACE),
+                spec=client.V1PersistentVolumeClaimSpec(
+                    access_modes=["ReadWriteOnce"],
+                    resources=client.V1ResourceRequirements(requests={"storage": "1Gi"}),
+                ),
+            )
+            await asyncio.to_thread(
+                core_v1.create_namespaced_persistent_volume_claim,
+                namespace=NAMESPACE,
+                body=pvc_manifest,
+            )
+            created_pvcs.append(pvc_name)
+            print(f"✅ PVC '{pvc_name}' created for testing")
+
+        devserver_spec = build_devserver_spec(
+            flavor=test_flavor,
+            public_key="ssh-rsa AAAA...",
+            ttl="1h",
+            image=None,
+            volumes=[
+                {
+                    "claimName": pvc_home,
+                    "mountPath": "/home/dev",
+                    "readOnly": False,
+                },
+                {
+                    "claimName": pvc_data,
+                    "mountPath": "/data",
+                    "readOnly": True,
+                },
+            ],
+        )
+
+        async with async_devserver(
+            devserver_name,
+            spec=devserver_spec,
+        ):
+            # Verify the Deployment mounts both PVCs
+            deployment = await wait_for_deployment_to_exist(
+                apps_v1, name=devserver_name, namespace=NAMESPACE
+            )
+
+            assert deployment is not None
+
+            # Check volumes
+            volumes = deployment.spec.template.spec.volumes
+            user_volumes = [v for v in volumes if v.name.startswith("user-volume-")]
+            assert len(user_volumes) == 2, f"Expected 2 user volumes, got {len(user_volumes)}"
+
+            # Check volume mounts
+            container = deployment.spec.template.spec.containers[0]
+            user_mounts = [
+                vm for vm in container.volume_mounts
+                if vm.name.startswith("user-volume-")
+            ]
+            assert len(user_mounts) == 2, f"Expected 2 user mounts, got {len(user_mounts)}"
+
+            # Verify specific mounts
+            mount_paths = {vm.mount_path: vm for vm in user_mounts}
+            assert "/home/dev" in mount_paths, "/home/dev mount not found"
+            assert "/data" in mount_paths, "/data mount not found"
+            assert mount_paths["/data"].read_only, "/data should be read-only"
+
+            print("✅ Multiple volumes correctly mounted")
+
+    finally:
+        # Cleanup PVCs
+        for pvc_name in created_pvcs:
+            try:
+                await asyncio.to_thread(
+                    core_v1.delete_namespaced_persistent_volume_claim,
+                    name=pvc_name,
+                    namespace=NAMESPACE,
+                )
+                print(f"🧹 PVC '{pvc_name}' deleted")
+            except client.ApiException as e:
+                if e.status != 404:
+                    print(f"⚠️ Error deleting PVC '{pvc_name}': {e}")
+
+
+@pytest.mark.asyncio
+async def test_pvc_persists_after_devserver_deletion(
+    test_flavor, operator_running, k8s_clients, async_devserver
+):
+    """
+    Tests that user-managed PVCs are NOT deleted when a DevServer is deleted.
+    """
+    core_v1 = k8s_clients["core_v1"]
+    devserver_name = "test-pvc-persistence"
+    pvc_name = "test-pvc-persistent"
+
+    # Create a PVC for testing
+    pvc_manifest = client.V1PersistentVolumeClaim(
+        metadata=client.V1ObjectMeta(name=pvc_name, namespace=NAMESPACE),
+        spec=client.V1PersistentVolumeClaimSpec(
+            access_modes=["ReadWriteOnce"],
+            resources=client.V1ResourceRequirements(requests={"storage": "1Gi"}),
+        ),
+    )
+
+    try:
+        await asyncio.to_thread(
+            core_v1.create_namespaced_persistent_volume_claim,
+            namespace=NAMESPACE,
+            body=pvc_manifest,
+        )
+        print(f"✅ PVC '{pvc_name}' created for testing")
+
+        devserver_spec = build_devserver_spec(
+            flavor=test_flavor,
+            public_key="ssh-rsa AAAA...",
+            ttl="1h",
+            image=None,
+            volumes=[
+                {
+                    "claimName": pvc_name,
+                    "mountPath": "/home/dev",
+                    "readOnly": False,
+                }
+            ],
+        )
+
+        async with async_devserver(
+            devserver_name,
+            spec=devserver_spec,
+        ):
+            await wait_for_devserver_status(
+                k8s_clients["custom_objects_api"],
+                name=devserver_name,
+                namespace=NAMESPACE,
+                expected_status="Running",
+            )
+            print(f"✅ DevServer '{devserver_name}' running")
+
+        # DevServer is now deleted (context manager exit)
+        # Verify PVC still exists
+        pvc = await asyncio.to_thread(
             core_v1.read_namespaced_persistent_volume_claim,
             name=pvc_name,
             namespace=NAMESPACE,
         )
-        print(f"✅ PVC '{pvc_name}' correctly retained after deletion.")
-    except client.ApiException as e:
-        if e.status == 404:
-            pytest.fail(
-                f"PVC '{pvc_name}' was deleted, but should have been retained."
+        assert pvc is not None, f"PVC '{pvc_name}' should still exist after DevServer deletion"
+        print(f"✅ PVC '{pvc_name}' correctly persisted after DevServer deletion")
+
+    finally:
+        # Cleanup PVC
+        try:
+            await asyncio.to_thread(
+                core_v1.delete_namespaced_persistent_volume_claim,
+                name=pvc_name,
+                namespace=NAMESPACE,
             )
-        raise
-
-    # 3. Re-creation
-    print("PHASE 3: Re-creating DevServer, verifying it re-attaches...")
-    async with async_devserver(
-        devserver_name,
-        spec=devserver_spec,
-    ):
-        # Wait for StatefulSet to be re-created and become ready
-        await wait_for_statefulset_to_exist(
-            apps_v1, name=devserver_name, namespace=NAMESPACE
-        )
-        await wait_for_devserver_status(
-            k8s_clients["custom_objects_api"],
-            name=devserver_name,
-            namespace=NAMESPACE,
-            expected_status="Running",
-        )
-
-    await wait_for_statefulset_to_be_deleted(
-        apps_v1, name=devserver_name, namespace=NAMESPACE
-    )
+            print(f"🧹 PVC '{pvc_name}' deleted")
+        except client.ApiException as e:
+            if e.status != 404:
+                print(f"⚠️ Error deleting PVC '{pvc_name}': {e}")


### PR DESCRIPTION
This commit refactors the devserver operator to use Deployments instead of StatefulSets to manage devserver pods. This change enables more flexible volume configurations, including support for mounting multiple persistent volumes into a devserver.

Key changes:
- Switched from `StatefulSet` to `Deployment` for managing devserver pods. This allows for more flexible update strategies and simplifies volume management.
- Updated the `DevServer` CRD (`devserver.io_devservers.yaml` and `src/devservers/crds/devserver.py`) to accept a list of volumes, allowing users to define multiple persistent storage volumes for their devservers.
- The operator now dynamically creates and manages `PersistentVolumeClaims` based on the volumes specified in the `DevServer` custom resource.
- Added new examples (`with-single-volume.yaml`, `with-multiple-volumes.yaml`) to demonstrate the new multi-volume capabilities.
- Updated tests, CLI commands, and documentation to align with the move to Deployments and multi-volume support.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>