### PR TITLE
fix(operator): specify UTC for expiration check

### DIFF
--- a/src/devservers/operator/devserver/lifecycle.py
+++ b/src/devservers/operator/devserver/lifecycle.py
@@ -105,7 +105,8 @@ def is_expired(devserver: dict, logger: logging.Logger) -> bool:
         if not ttl_str:
             return False
 
-        creation_timestamp = datetime.fromisoformat(creation_timestamp_str)
+        # Handle 'Z' for UTC timezone explicitly for wider Python compatibility
+        creation_timestamp = datetime.fromisoformat(creation_timestamp_str.replace("Z", "+00:00"))
         ttl_delta = parse_duration(ttl_str)
         expiration_time = creation_timestamp + ttl_delta
         return datetime.now(timezone.utc) > expiration_time


### PR DESCRIPTION
This was a longstanding bug where the expiration check was failing tests.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>