### PR TITLE
feat(flavors): Add volume support to DevServerFlavors

### DIFF
--- a/crds/devserver.io_devserverflavors.yaml
+++ b/crds/devserver.io_devserverflavors.yaml
@@ -42,6 +42,18 @@ spec:
                   items:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                volumes:
+                  type: array
+                  items:
+                    type: object
+                    required: ["claimName", "mountPath"]
+                    properties:
+                      claimName:
+                        type: string
+                      mountPath:
+                        type: string
+                      readOnly:
+                        type: boolean
             status:
               type: object
               properties:

--- a/examples/flavors/storage-small.yaml
+++ b/examples/flavors/storage-small.yaml
@@ -1,0 +1,17 @@
+apiVersion: devserver.io/v1
+kind: DevServerFlavor
+metadata:
+  name: storage-small
+spec:
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+  volumes:
+    - claimName: "my-data-pvc"
+      mountPath: "/data"
+    - claimName: "my-home-pvc"
+      mountPath: "/home/dev"

--- a/src/devservers/operator/README.md
+++ b/src/devservers/operator/README.md
@@ -54,6 +54,8 @@ spec:
 
 Tolerations can also be specified to allow DevServers to be scheduled on nodes with matching taints, such as GPU nodes.
 
+In addition to compute resources, flavors can specify a list of `volumes` to be mounted into the DevServer. This is useful for providing shared storage, datasets, or pre-configured environments. Volumes specified directly in a `DevServer` will override flavor volumes with the same `mountPath`.
+
 Cluster administrators can mark a flavor as the default by setting `spec.default: true`. When a default flavor is configured, users can create DevServers without explicitly specifying a flavor. Only one flavor can be marked as default at a time.
 
 **Example `DevServerFlavor`:**
@@ -78,6 +80,10 @@ spec:
     - key: "nvidia.com/gpu"
       operator: "Exists"
       effect: "NoSchedule"
+  volumes:
+    - claimName: "shared-data"
+      mountPath: "/data"
+      readOnly: true
 status:
   schedulable: "Yes"
 ```

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -619,6 +619,20 @@ async def test_flavor_with_volume_mounts(
                 assert flavor_mount.mount_path == "/data"
                 print(f"✅ DevServer correctly mounted volume from flavor '{flavor_name}'")
 
+                # Ensure /home/dev is still backed by emptyDir when not overridden
+                home_volume = next(
+                    (v for v in deployment.spec.template.spec.volumes if v.name == "home"),
+                    None,
+                )
+                assert home_volume is not None
+                assert home_volume.empty_dir is not None
+                home_mount = next(
+                    (vm for vm in container.volume_mounts if vm.mount_path == "/home/dev"),
+                    None,
+                )
+                assert home_mount is not None
+                assert home_mount.name == "home"
+
 
 @pytest.mark.asyncio
 async def test_flavor_and_devserver_volumes_merge(


### PR DESCRIPTION
This commit introduces the ability to specify a list of volumes to be mounted within `DevServerFlavor` resources. This allows administrators to create more comprehensive, standardized development environment templates that include pre-configured storage.

Key changes:

- The `DevServerFlavor` CRD has been updated to include an optional `volumes` field in its spec. Each volume specifies a `claimName` and `mountPath`.

- The `DevServer` operator's deployment reconciliation logic has been modified to merge volumes from both the `DevServerFlavor` and the `DevServer` spec.

- If a volume in the `DevServer` spec has the same `mountPath` as a volume in the flavor, the `DevServer`'s volume will take precedence, allowing for per-instance overrides.

- Added comprehensive tests to `tests/test_storage.py` to validate:
  - Volumes from flavors are correctly mounted.
  - Merging of flavor and devserver volumes.
  - Overriding of flavor volumes by devserver volumes.

- Updated `src/devservers/operator/README.md` to document the new feature and added `examples/flavors/storage-small.yaml` as a usage example.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>