### PR TITLE
feat: Add support for default images in DevServer flavors

### DIFF
--- a/crds/devserver.io_devserverflavors.yaml
+++ b/crds/devserver.io_devserverflavors.yaml
@@ -25,6 +25,8 @@ spec:
               properties:
                 default:
                   type: boolean
+                defaultImage:
+                  type: string
                 resources:
                   type: object
                   properties:

--- a/src/devservers/operator/README.md
+++ b/src/devservers/operator/README.md
@@ -67,6 +67,7 @@ metadata:
   name: cpu-small
 spec:
   default: true  # Optional: mark this as the default flavor
+  defaultImage: "ubuntu:22.04"
   resources:
     requests:
       cpu: "500m"
@@ -143,44 +144,4 @@ The DevServer Operator is configured via a ConfigMap, which is mounted into the 
 -   `flavorReconciliationInterval`: Interval in seconds for reconciling `DevServerFlavor` statuses. Defaults to `60`. Can be overridden by the `DEVSERVER_FLAVOR_RECONCILIATION_INTERVAL` environment variable.
 -   `workerLimit`: The maximum number of concurrent reconciliations. This helps to prevent overwhelming the Kubernetes API server. Defaults to `1`. Can be overridden by the `DEVSERVER_WORKER_LIMIT` environment variable.
 -   `postingEnabled`: Whether to post reconciliation logs as Kubernetes events. It is recommended to keep this `false` to reduce API server load. Defaults to `false`. Can be overridden by the `DEVSERVER_POSTING_ENABLED` environment variable.
--   `defaultDevserverImage`: The default container image to use for `DevServers` if not specified in the `spec.image`. Defaults to `seemethere/devserver-base:latest`. Can be overridden by the `DEVSERVER_DEFAULT_DEVSERVER_IMAGE` environment variable.
--   `staticDependenciesImage`: The container image to use for the init container that provides static dependencies like `sshd`. Defaults to `seemethere/devserver-static-dependencies:latest`. Can be overridden by the `DEVSERVER_STATIC_DEPENDENCIES_IMAGE` environment variable.
-
-### Example ConfigMap
-
-An example `ConfigMap` can be found at `examples/operator-config.yaml`. This can be customized and applied to your cluster.
-
-```yaml
-# examples/operator-config.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: devserver-operator-config
-  namespace: devserver-operator # Or the namespace where your operator is running
-data:
-  config.yaml: |
-    # Default size for persistent home directories if not specified in the DevServer spec.
-    # Accepts standard Kubernetes quantity format (e.g., 10Gi, 500Mi).
-    defaultPersistentHomeSize: 20Gi
-
-    # Interval in seconds for checking for expired DevServers.
-    expirationInterval: 60
-
-    # Interval in seconds for reconciling DevServerFlavor statuses.
-    flavorReconciliationInterval: 60
-
-    # Maximum number of concurrent reconciliations.
-    workerLimit: 1
-
-    # Whether to post reconciliation logs as Kubernetes events.
-    postingEnabled: false
-
-    # Default image for DevServers if not specified in the spec.
-    defaultDevserverImage: "seemethere/devserver-base:latest"
-
-    # Image for the init container that provides static dependencies like sshd.
-    staticDependenciesImage: "seemethere/devserver-static-dependencies:latest"
-
-### Applying the Configuration
-
-To apply this configuration, you would create the `ConfigMap` in the same namespace as the operator and then mount it as a volume in the operator's `Deployment`. The volume should be mounted at `/etc/devserver-operator/`, and the `DEVSERVER_OPERATOR_CONFIG_PATH` environment variable can be set to `/etc/devserver-operator/config.yaml`.
+-   `defaultDevserverImage`: The default container image to use for `

--- a/src/devservers/operator/devserver/resources/deployment.py
+++ b/src/devservers/operator/devserver/resources/deployment.py
@@ -12,7 +12,9 @@ def build_deployment(
     static_dependencies_image: str,
 ) -> Dict[str, Any]:
     """Builds the Deployment for the DevServer."""
-    image = spec.get("image", default_devserver_image)
+    image = spec.get("image")
+    if not image:
+        image = flavor["spec"].get("defaultImage", default_devserver_image)
 
     # Get the public key from the spec
     ssh_public_key = spec.get("ssh", {}).get("publicKey", "")

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -325,6 +325,30 @@ def test_build_deployment_uses_recreate_strategy():
     assert deployment["spec"].get("strategy") == {"type": "Recreate"}
 
 
+def test_build_deployment_uses_flavor_default_image():
+    name = "test-server"
+    namespace = "test-ns"
+    spec = {}
+    flavor = {
+        "spec": {
+            "defaultImage": "flavor-image",
+            "resources": {}
+        }
+    }
+
+    deployment = build_deployment(
+        name,
+        namespace,
+        spec,
+        flavor,
+        default_devserver_image="default-image",
+        static_dependencies_image="static-image",
+    )
+
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    assert container["image"] == "flavor-image"
+
+
 def test_compute_user_namespace_default():
     spec = {"username": "alice"}
     reconciler = DevServerUserReconciler(spec=spec, metadata={})


### PR DESCRIPTION
This change allows DevServerFlavors to specify a default image. If a
DevServer does not define an image in its spec, the operator will now
check the selected flavor for a `defaultImage` before falling back to
the global default.

Changes:
- Update `DevServerFlavor` CRD to include optional `defaultImage` field.
- Update operator logic to use flavor's `defaultImage` when applicable.
- Add unit tests to verify flavor default image selection.
- Update documentation to include `defaultImage` in `DevServerFlavor` example.

Example flavor configuration:

    apiVersion: devserver.io/v1
    kind: DevServerFlavor
    metadata:
      name: python-dev
    spec:
      defaultImage: python:3.11-slim
      resources:
        requests:
          cpu: "500m"
          memory: "1Gi"

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>